### PR TITLE
refactor: include carousel-arrow as a yielded param

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These parameters `ui` and `act` can be called anything, but they contain the fol
 
 - `ui` - is a hash with the following component items:
   * `item` - A component that should contain your slide contents, used like so `{{ui.item}}you content{{/ui.item}}`.
+  * `[left|right]-trigger` - Two components (`left-trigger` & `right-trigger`) that are pre-wired with the slide action and class name.
 - `controls` - is a hash with the following action items:
   * `previous` - A closure action that changes to the previous slide.
   * `next` - A closure action that changes to the next slide.

--- a/addon/components/carousel-arrow.js
+++ b/addon/components/carousel-arrow.js
@@ -7,21 +7,11 @@ const carouselArrowClassMap = {
   right: 'carousel-right-arrow'
 };
 
-const carouselSlideActionMap = {
-  left: 'slideLeft',
-  right: 'slideRight'
-};
-
 export default Component.extend({
   classNameBindings: ['carousel-arrow-class'],
   layout,
 
   'carousel-arrow-class': computed('direction', function() {
     return carouselArrowClassMap[get(this, 'direction')];
-  }),
-
-  click() {
-    let method = carouselSlideActionMap[get(this, 'direction')];
-    this.nearestWithProperty('isCarouselParentContainer')[method]();
-  }
+  })
 });

--- a/addon/templates/components/carousel-container.hbs
+++ b/addon/templates/components/carousel-container.hbs
@@ -3,6 +3,12 @@
     item=(component 'carousel-item'
       register=(action 'registerItem')
       allItems=carouselItems)
+    left-trigger=(component 'carousel-arrow'
+      direction='left'
+      click=(action 'slideLeft'))
+    right-trigger=(component 'carousel-arrow'
+      direction='right'
+      click=(action 'slideRight'))
   )
   (hash
     previous=(action 'slideLeft')

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -14,8 +14,8 @@
       {{/ui.item}}
     </div>
 
-    <div class="line-arrow left" onclick={{act.previous}}></div>
-    <div class="line-arrow right" onclick={{act.next}}></div>
+    {{ui.left-trigger class="line-arrow left"}}
+    {{ui.right-trigger class="line-arrow right"}}
   {{/carousel-container}}
 
   <div class="image-credits">


### PR DESCRIPTION
Changes:
- Yields the `carousel-arrow` component for a left and right trigger, which is pre-wired with the slide action and a default class name
- This also removes the usage of the deprecated [`nearestWithProperty`](https://github.com/emberjs/ember.js/blob/f73d8440d19cf86a10c61ddb89d45881acfcf974/packages/%40ember/-internals/views/lib/mixins/view_support.js#L101-L119) method